### PR TITLE
nullをセットする

### DIFF
--- a/lib/providers/tasks.dart
+++ b/lib/providers/tasks.dart
@@ -27,8 +27,8 @@ class Tasks with ChangeNotifier {
         id: data.id,
         title: data.data()['title'],
         detail: data.data()['detail'],
-        due: due.toDate(),
-        createdAt: createdAt.toDate(),
+        due: due != null ? due.toDate() : null,
+        createdAt: due != null ? createdAt.toDate() : null,
       );
       _items.add(task);
     });


### PR DESCRIPTION
- タスクデータセット時、クラッシュを防ぐため、nullを代入する